### PR TITLE
fix: remove _get_entity_type method from advanced base class 

### DIFF
--- a/doc/release/release_notes.rst
+++ b/doc/release/release_notes.rst
@@ -7,6 +7,12 @@
 Release Notes
 *************
 
+.. release:: Upcoming
+
+    .. change:: changed
+        :tags: API
+
+        Remove _get_entity_type from AdvancedBaseAction and rely on base class implementation.
 
 .. release:: 0.3.0
     :date: 2022-05-11

--- a/source/ftrack_action_handler/action/advanced.py
+++ b/source/ftrack_action_handler/action/advanced.py
@@ -250,30 +250,6 @@ class AdvancedBaseAction(BaseAction):
             return True
         return True
 
-    def _get_entity_type(self, entity):
-        '''Return translated entity type that can be used with API.'''
-        # Get entity type and make sure it is lower cased. Most places except
-        # the component tab in the Sidebar will use lower case notation.
-        entity_type = entity.get('entityType').replace('_', '').lower()
-
-        for schema in self.session.schemas:
-            alias_for = schema.get('alias_for')
-
-            if (
-                    alias_for
-                    and isinstance(alias_for, str)
-                    and alias_for.lower() == entity_type
-            ):
-                return schema['id']
-
-        for schema in self.session.schemas:
-            if schema['id'].lower() == entity_type:
-                return schema['id']
-
-        raise ValueError(
-            'Unable to translate entity type: {0}.'.format(entity_type)
-        )
-
     # --------------------------------------------------------------
     # Default Action Method Overwrites
     # --------------------------------------------------------------


### PR DESCRIPTION
Resolves CLICKUP-2ejccbe

- [ ] I have added automatic tests where applicable
- [ ] The PR title is suitable as a release note
- [ ] The PR contains a description of what has been changed
- [ ] The description contains manual test instructions

## Changes

remove reimplemented  _get_entity_type from AdvancedBaseAction and rely on baseclass implementation.

## Test

Not really , just ensure it does pick up the base class
